### PR TITLE
Updated start date picker onDayChange prop to call datesChanged with …

### DIFF
--- a/components/DateRangePicker.js
+++ b/components/DateRangePicker.js
@@ -1,45 +1,44 @@
-import { useState } from "react"
+import { useState } from "react";
 
-import DayPickerInput from "react-day-picker/DayPickerInput"
-import { DateUtils } from "react-day-picker"
+import DayPickerInput from "react-day-picker/DayPickerInput";
+import { DateUtils } from "react-day-picker";
 
-import "react-day-picker/lib/style.css"
-import dateFnsFormat from "date-fns/format"
-import dateFnsParse from "date-fns/parse"
+import "react-day-picker/lib/style.css";
+import dateFnsFormat from "date-fns/format";
+import dateFnsParse from "date-fns/parse";
 
 const parseDate = (str, format, locale) => {
-  const parsed = dateFnsParse(str, format, new Date(), { locale })
-  return DateUtils.isDate(parsed) ? parsed : null
-}
+  const parsed = dateFnsParse(str, format, new Date(), { locale });
+  return DateUtils.isDate(parsed) ? parsed : null;
+};
 
-const formatDate = (date, format, locale) =>
-  dateFnsFormat(date, format, { locale })
+const formatDate = (date, format, locale) => dateFnsFormat(date, format, { locale });
 
-const format = "dd MMM yyyy"
+const format = "dd MMM yyyy";
 
-const today = new Date()
-const tomorrow = new Date(today)
-tomorrow.setDate(tomorrow.getDate() + 1)
+const today = new Date();
+const tomorrow = new Date(today);
+tomorrow.setDate(tomorrow.getDate() + 1);
 
 const numberOfNightsBetweenDates = (startDate, endDate) => {
-  const start = new Date(startDate) //clone
-  const end = new Date(endDate) //clone
-  let dayCount = 0
+  const start = new Date(startDate); //clone
+  const end = new Date(endDate); //clone
+  let dayCount = 0;
 
   while (end > start) {
-    dayCount++
-    start.setDate(start.getDate() + 1)
+    dayCount++;
+    start.setDate(start.getDate() + 1);
   }
 
-  return dayCount
-}
+  return dayCount;
+};
 
 export default function DateRangePicker({ datesChanged }) {
-  const [startDate, setStartDate] = useState(today)
-  const [endDate, setEndDate] = useState(tomorrow)
+  const [startDate, setStartDate] = useState(today);
+  const [endDate, setEndDate] = useState(tomorrow);
 
   return (
-    <div className='date-range-picker-container'>
+    <div className="date-range-picker-container">
       <div>
         <label>From:</label>
         <DayPickerInput
@@ -51,18 +50,20 @@ export default function DateRangePicker({ datesChanged }) {
           dayPickerProps={{
             modifiers: {
               disabled: {
-                before: new Date()
-              }
-            }
+                before: new Date(),
+              },
+            },
           }}
-          onDayChange={day => {
-            setStartDate(day)
-            const newEndDate = new Date(day)
+          onDayChange={(day) => {
+            setStartDate(day);
             if (numberOfNightsBetweenDates(day, endDate) < 1) {
-              newEndDate.setDate(newEndDate.getDate() + 1)
-              setEndDate(newEndDate)
+              const newEndDate = new Date(day);
+              newEndDate.setDate(newEndDate.getDate() + 1);
+              setEndDate(newEndDate);
+              datesChanged(day, newEndDate);
+            } else {
+              datesChanged(day, endDate);
             }
-            datesChanged(day, newEndDate)
           }}
         />
       </div>
@@ -79,14 +80,14 @@ export default function DateRangePicker({ datesChanged }) {
               disabled: [
                 startDate,
                 {
-                  before: startDate
-                }
-              ]
-            }
+                  before: startDate,
+                },
+              ],
+            },
           }}
-          onDayChange={day => {
-            setEndDate(day)
-            datesChanged(startDate, day)
+          onDayChange={(day) => {
+            setEndDate(day);
+            datesChanged(startDate, day);
           }}
         />
       </div>
@@ -112,5 +113,5 @@ export default function DateRangePicker({ datesChanged }) {
         `}
       </style>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
…day, endDate instead of day, newEndDate when newEndDate has not been changed because newEndDate is still const newEndDate = new Date(day) and you are telling the parent component the endDate is equal to the start date you just set

You can see this happen in your screen shots in the blog post in the console.log when the start date and end date are sent to the parent component and they are equal because the end date did not need to be updated so newEndDate is still equal to its initial value.

Thank you so much for all the content you create! I loved your JS bootcamp and I am loving this series!